### PR TITLE
Fix xul file address

### DIFF
--- a/src/modules/slLauncher.jsm
+++ b/src/modules/slLauncher.jsm
@@ -66,7 +66,7 @@ var slLauncher = {
     openBrowser : function(callback, parentWindow) {
         if (!parentWindow)
             parentWindow = windowMediator.getMostRecentWindow("slimerjs");
-        return parentWindow.openDialog("webpage.xul", "_blank", "chrome,all,dialog=no", { callback:callback});
+        return parentWindow.openDialog("chrome://slimerjs/content/webpage.xul", "_blank", "chrome,all,dialog=no", { callback:callback});
     },
 
     closeBrowser: function (browser) {


### PR DESCRIPTION
When using  slimerJS with node-phantom, `node-phantom` will open a control page at http://127.0.0.1:32884/. Without this patch, next page open will open http://127.0.0.1:32884/webpage.xul instead of chrome://slimerjs/content/webpage.xul
