### PR TITLE
Incorrect case for evaluateJavaScript

### DIFF
--- a/src/modules/slimer-sdk/webpage.js
+++ b/src/modules/slimer-sdk/webpage.js
@@ -742,7 +742,7 @@ function create() {
             return evalInSandbox(func);
         },
 
-        evaluateJavascript: function(src) {
+        evaluateJavaScript: function(src) {
             if (!browser)
                 throw "WebPage not opened";
 


### PR DESCRIPTION
SlimerJS is exposing method `page.evaluateJavascript` but PhantomJS spell it `page.evaluateJavaScript` (tested with 1.6.0 and 1.8.2)
