### PR TITLE
Fix so that the proxy settings are used for HTTPS connections too

### DIFF
--- a/src/modules/slConfiguration.jsm
+++ b/src/modules/slConfiguration.jsm
@@ -181,6 +181,8 @@ var slConfiguration = {
                 if (this.proxyHost) {
                     Services.prefs.setCharPref('network.proxy.http', this.proxyHost)
                     Services.prefs.setIntPref('network.proxy.http_port', this.proxyPort);
+                    Services.prefs.setCharPref('network.proxy.ssl', this.proxyHost)
+                    Services.prefs.setIntPref('network.proxy.ssl_port', this.proxyPort);
                     Services.prefs.setIntPref('network.proxy.type',1);
                 }
                 else {
@@ -208,6 +210,8 @@ var slConfiguration = {
                 if (this.proxy != '') {
                     Services.prefs.setCharPref('network.proxy.http', this.proxyHost)
                     Services.prefs.setIntPref('network.proxy.http_port', this.proxyPort);
+                    Services.prefs.setCharPref('network.proxy.ssl', this.proxyHost)
+                    Services.prefs.setIntPref('network.proxy.ssl_port', this.proxyPort);
                     Services.prefs.setIntPref('network.proxy.type',1);
                     break;
                 }


### PR DESCRIPTION
Before HTTPS connections didn't go via the proxy, with this change, the same proxy configuration is used for HTTPS as HTTP when using a HTTP proxy.
