### PR TITLE
Fixes #158: correctly deal with env vars containing spaces

### DIFF
--- a/src/slimerjs
+++ b/src/slimerjs
@@ -109,10 +109,13 @@ function showHelp() {
 # list
 LISTVAR=""
 ENVVAR=`env`;
+OLDIFS=$IFS;
+IFS=$'\n';
 for v in $ENVVAR; do
     IFS='=' read -a var <<< "$v"
     LISTVAR="$LISTVAR,${var[0]}"
 done
+IFS=$OLDIFS;
 
 # check arguments.
 CREATE_TEMP='Y'


### PR DESCRIPTION
I had some env vars with spaces in them and lead to duplicate keys
