### PR TITLE
Improve documentation of require() phantomjs differences.

### DIFF
--- a/docs/differences-with-phantomjs.rst
+++ b/docs/differences-with-phantomjs.rst
@@ -89,8 +89,8 @@ In the API
      modules loaded with ``require``
    - Modules are completely impervious. They are executed in a truly javascript
      sandbox
-   - SlimerJS provides an API to indicate paths where modules can be found:
-     ``require.paths`` (CommonJS specification).
+   - Modules must be files, not folders.  ``node_modules`` folders are not
+     searched specially (SlimerJS provides ``require.paths``).
 - Exit code doesn't work with SlimerJS (There is no API for that in Gecko)
 - The callback ``webpage.onNavigationRequest`` receives bad parameters.
   Don't rely on the ``navigationType`` and the ``isMainFrame`` values (because of


### PR DESCRIPTION
Support for require.paths is no longer a difference, per https://github.com/ariya/phantomjs/issues/11339 . 
And an important difference was not mentioned - PhantomJS has additional search rules.

If phantomjs is run in a directory containing a ./node_modules/mocha/ installation of mocha, these two work:
  phantomjs> require('./node_modules/mocha')
  phantomjs> require('mocha')

The first requires searching from a module directory to a file.
The second requires searching a node_modules hierarchy.
SlimerJS does not do these.

This commit adds the missing differences, and removes the obsolete one.  A mention of require.paths is retained, so there's little information loss.
