### PR TITLE
Find the default global Firefox install on Mac OSX automatically

### DIFF
--- a/src/slimerjs
+++ b/src/slimerjs
@@ -31,17 +31,17 @@ then
         then
             SLIMERJSLAUNCHER="$SLIMERDIR/xulrunner/xulrunner.exe"
         else
-            # Try the Mac OSX global default application path
-            if [ -f "/Applications/Firefox.app/Contents/MacOS/firefox" ]
+            SLIMERJSLAUNCHER=`command -v firefox`
+            if [ "$SLIMERJSLAUNCHER" == "" ]
             then
-                SLIMERJSLAUNCHER="/Applications/Firefox.app/Contents/MacOS/firefox"
-            else
-                SLIMERJSLAUNCHER=`command -v firefox`
+                SLIMERJSLAUNCHER=`command -v xulrunner`
                 if [ "$SLIMERJSLAUNCHER" == "" ]
                 then
-                    SLIMERJSLAUNCHER=`command -v xulrunner`
-                    if [ "$SLIMERJSLAUNCHER" == "" ]
+                    # Try the Mac OSX global default application path
+                    if [ -f "/Applications/Firefox.app/Contents/MacOS/firefox" ]
                     then
+                        SLIMERJSLAUNCHER="/Applications/Firefox.app/Contents/MacOS/firefox"
+                    else
                         echo "SLIMERJSLAUNCHER environment variable is missing. Set it with the path to Firefox or XulRunner"
                         exit 1
                     fi


### PR DESCRIPTION
Before falling back to finding the `firefox` executable through standard Unix means, this change lets SlimerJS check the default global Firefox install path on Mac OSX.

This should hopefully capture 95% of Firefox installs on Mac OSX.

For me this would solve issue #172.
