### PR TITLE
Fix typo Os -> OS X, Drop the 'Mac'

### DIFF
--- a/website/download.html
+++ b/website/download.html
@@ -134,7 +134,7 @@
                 </div>
                 <div class="span5">
                 <h2>Homebrew</h2>
-                <p><a href="http://brew.sh/">This package system for MacOs</a> has a formula
+                <p><a href="http://brew.sh/">This package system for OS X</a> has a formula
                 to install SlimerJS. Type in a console:</p>
                 <pre><code>brew install slimerjs</code></pre>
                 <p>You have to install XulRunner or Firefox separately and set the SLIMERJSLAUNCHER


### PR DESCRIPTION
Apple officially renamed Mac OS X to OS X.

http://www.theverge.com/2012/2/16/2802281/apple-officially-renames-mac-os-x-to-os-x-drops-the-mac
