### PR TITLE
Fix for issue 196

### DIFF
--- a/src/slimerjs.bat
+++ b/src/slimerjs.bat
@@ -2,7 +2,9 @@
 
 REM % ~ d[rive] p[ath] 0[script name] is the absolute path to this bat file, without quotes, always.
 REM ~ strips quotes from the argument
+if not exist %SLIMERDIR% (
 SET SLIMERDIR=%~dp0
+)
 REM %* is every argument passed to this script.
 SET __SLIMER_ARGS=%*
 SET __SLIMER_ENV=


### PR DESCRIPTION
Issue #196 covers two problems:

1) The .bat file(s) on Windows work too hard, end up double quoting the SLIMERJSLAUNCHER environment variable when it's deduced by the script. It's probably better to expect those who set it manually to quote it correctly. (An alternative fix would be not quoting it where it's first deduced and let slimerjs.bat deal with it)

2) Sometimes (if slimerjs.bat is called from other .bat files, like a Casper one), you can't correctly read the directory slimerjs.bat lives in with the %~dp0 command. Therefore we should allow users to set SLIMERDIR environment variable manually and not override it if it's set.

All based on http://luksurious.me/?p=64 - thanks!
