### PR TITLE
Fixed and extended render PDF

### DIFF
--- a/docs/api/webpage.rst
+++ b/docs/api/webpage.rst
@@ -935,6 +935,7 @@ ignored. And it supports additionnal properties:
 - ``resolution``: in dpi. By default: 300.
 - ``marginTop``, ``marginRight``, ``marginBottom``, ``marginLeft``: margin as millimeters
 - ``unwriteableMarginTop``, ``unwriteableMarginRight``, ``unwriteableMarginBottom``, ``unwriteableMarginLeft``: unwriteable margin as millimeters
+- ``edgeTop``, ``edgeRight``, ``edgeBottom``, ``edgeLeft``: positioning of the headers and footers on the page. They're measured in milimeters as an offset from the unwriteable margin
 - ``height``, ``width``: in milimeters, by default the viewport size
 - ``orientation``: page orientation (0 - portrait, 1 - landscape)
 - ``shrinkToFit``: try to fit content in page (bool) 

--- a/docs/api/webpage.rst
+++ b/docs/api/webpage.rst
@@ -934,9 +934,24 @@ ignored. And it supports additionnal properties:
 
 - ``resolution``: in dpi. By default: 300.
 - ``marginTop``, ``marginRight``, ``marginBottom``, ``marginLeft``: margin as millimeters
-- ``unwriteableMarginTop``, ``unwriteableMarginRight``,
-   ``unwriteableMarginBottom``, ``unwriteableMarginLeft``: unwriteable margin as millimeters
-- ``height``, ``width``: by default, the viewport size.
+- ``unwriteableMarginTop``, ``unwriteableMarginRight``, ``unwriteableMarginBottom``, ``unwriteableMarginLeft``: unwriteable margin as millimeters
+- ``height``, ``width``: in milimeters, by default the viewport size
+- ``orientation``: page orientation (0 - portrait, 1 - landscape)
+- ``shrinkToFit``: try to fit content in page (bool) 
+- ``printBGColors``, ``printBGImages``: control printing of background colors and images (bool)
+- ``title``: title of printed content
+- ``footerStrCenter``, ``footerStrLeft``, ``footerStrRight``, ``headerStrCenter``, ``headerStrLeft``, ``headerStrRight`` : page header and footer, there are special variables that can be used in header and footer:
+
+ ====================  ===========================================================
+ Variable              Description
+ ====================  ===========================================================
+ ``&T``                title
+ ``&U``                URL
+ ``&D``                date/time
+ ``&P``                current page number
+ ``&PT``               total number of pages in form "*page* ``of`` *total*"
+ ``&L``                last page number   
+ ====================  ===========================================================
 
 Note: On MacOSx, you probably have to install a "PDF driver" as a printer on your system.
 See for example `PDFWriter for mac <http://sourceforge.net/projects/pdfwriterformac/>`_.

--- a/src/application.ini
+++ b/src/application.ini
@@ -2,7 +2,7 @@
 Vendor=Innophi
 Name=SlimerJS
 Version=0.10.0pre
-BuildID=20140811
+BuildID=20150217
 ID=slimerjs@slimerjs.org
 Copyright=Copyright 2012-2014 Laurent Jouanneau & Innophi
 

--- a/src/modules/slimer-sdk/webpage.js
+++ b/src/modules/slimer-sdk/webpage.js
@@ -1481,10 +1481,9 @@ function _create(parentWebpageInfo) {
             let file = fs.absolute(filename);
 
             try {
-                let finalOptions = webpageUtils.getScreenshotOptions(this, options, fs.extension(file));
+                let finalOptions = webpageUtils.getRenderOptions(this, options, fs.extension(file));
                 if (finalOptions.format == 'pdf') {
-                    let printOptions = webpageUtils.getPrintOptions(this, finalOptions);
-                    return webpageUtils.renderPageAsPDF(browser.contentWindow, file, printOptions);
+                    return webpageUtils.renderPageAsPDF(browser.contentWindow, file, finalOptions);
                 }
 
                 let canvas = webpageUtils.getScreenshotCanvas(

--- a/src/modules/webpageUtils.jsm
+++ b/src/modules/webpageUtils.jsm
@@ -325,6 +325,10 @@ var webpageUtils = {
             marginRight: 0,
             marginBottom: 0,
             marginLeft: 0,
+            edgeTop: 0,
+            edgeLeft: 0,
+            edgeBottom: 0,
+            edgeRight: 0,
             unwriteableMarginTop: 0,
             unwriteableMarginRight: 0,
             unwriteableMarginBottom: 0,
@@ -512,6 +516,7 @@ var webpageUtils = {
     /**
      * print the given content window into a PDF.
      * The code has been inspired by http://mxr.mozilla.org/mozilla-central/source/mobile/android/chrome/content/browser.js#932
+     * About nsIPrintSettings interface you can read http://lxr.mozilla.org/mozilla-central/source/widget/nsIPrintSettings.idl     
      */
     renderPageAsPDF : function(contentWindow, file, options) {
         let printSettings = Cc["@mozilla.org/gfx/printsettings-service;1"]
@@ -532,11 +537,18 @@ var webpageUtils = {
         printSettings.headerStrCenter         = options.headerStrCenter;
         printSettings.headerStrLeft           = options.headerStrLeft;
         printSettings.headerStrRight          = options.headerStrRight;
+
         // Warning! Margins are always in Inches independent of paperSizeUnit
         printSettings.marginTop               = options.marginTop/25.4;
         printSettings.marginRight             = options.marginRight/25.4;
         printSettings.marginBottom            = options.marginBottom/25.4;
         printSettings.marginLeft              = options.marginLeft/25.4;
+
+        printSettings.edgeTop                 = options.edgeTop/25.4;
+        printSettings.edgeLeft                = options.edgeLeft/25.4;
+        printSettings.edgeBottom              = options.edgeBottom/25.4;
+        printSettings.edgeRight               = options.edgeRight/25.4;
+
         printSettings.unwriteableMarginTop    = options.unwriteableMarginTop/25.4;
         printSettings.unwriteableMarginRight  = options.unwriteableMarginRight/25.4;
         printSettings.unwriteableMarginBottom = options.unwriteableMarginBottom/25.4;

--- a/src/modules/webpageUtils.jsm
+++ b/src/modules/webpageUtils.jsm
@@ -302,7 +302,7 @@ var webpageUtils = {
             shrinkToFit: true,
             format: 'pdf',
             // Convert pixels to milimeters. Viewport is in pixels
-				// http://www.w3.org/TR/CSS21/syndata.html#length-units 
+            // http://www.w3.org/TR/CSS21/syndata.html#length-units 
             height: currentViewport.height/96*25.4,
             width: currentViewport.width/96*25.4,
             // orientation: 0 - portrait, 1 - landscape 
@@ -311,16 +311,16 @@ var webpageUtils = {
             resolution: 300, // dpi
             printBGImages: true,
             printBGColors: true,
-            title: "",
+            title: webpage.title,
             // Header and footer
-				footerStrCenter : "",
-				footerStrLeft : "",
-				footerStrRight : "",
-				headerStrCenter : "",
-				headerStrLeft : "",
-				headerStrRight : "",
+            footerStrCenter : "",
+            footerStrLeft : "",
+            footerStrRight : "",
+            headerStrCenter : "",
+            headerStrLeft : "",
+            headerStrRight : "",
             // here margins are in milimeters, but when they is passed to
-				// nsIPrintSetting must be converted in inches! 
+            // nsIPrintSetting must be converted in inches! 
             marginTop: 0,
             marginRight: 0,
             marginBottom: 0,

--- a/src/modules/webpageUtils.jsm
+++ b/src/modules/webpageUtils.jsm
@@ -299,11 +299,28 @@ var webpageUtils = {
 
         let printOptions = {
             ratio: webpage.zoomFactor,
+            shrinkToFit: true,
             format: 'pdf',
-            height: currentViewport.height,
-            width: currentViewport.width,
+            // Convert pixels to milimeters. Viewport is in pixels
+				// http://www.w3.org/TR/CSS21/syndata.html#length-units 
+            height: currentViewport.height/96*25.4,
+            width: currentViewport.width/96*25.4,
+            // orientation: 0 - portrait, 1 - landscape 
+            orientation : 0,
             onlyViewport: false,
             resolution: 300, // dpi
+            printBGImages: true,
+            printBGColors: true,
+            title: "",
+            // Header and footer
+				footerStrCenter : "",
+				footerStrLeft : "",
+				footerStrRight : "",
+				headerStrCenter : "",
+				headerStrLeft : "",
+				headerStrRight : "",
+            // here margins are in milimeters, but when they is passed to
+				// nsIPrintSetting must be converted in inches! 
             marginTop: 0,
             marginRight: 0,
             marginBottom: 0,
@@ -313,7 +330,6 @@ var webpageUtils = {
             unwriteableMarginBottom: 0,
             unwriteableMarginLeft: 0
         };
-
         if (typeof(options) == 'object') {
           for (var attr in options) { printOptions[attr] = options[attr]; }
         }
@@ -375,6 +391,15 @@ var webpageUtils = {
         return finalOptions;
     },
 
+    getRenderOptions : function(webpage, options, alternateFormat) {
+    	let finalOptions = this.getScreenshotOptions(webpage, options, alternateFormat);
+    	if (finalOptions.format == "pdf") {
+    		options.format = "pdf"; // override
+    		finalOptions = this.getPrintOptions(webpage, options); 
+    	}
+    	return finalOptions;
+    },
+	
     getScreenshotCanvas : function(window, ratio, onlyViewport, webpage) {
 
         if (!ratio || (ratio && ratio <= 0)) {
@@ -492,36 +517,40 @@ var webpageUtils = {
         let printSettings = Cc["@mozilla.org/gfx/printsettings-service;1"]
                                 .getService(Ci.nsIPrintSettingsService)
                                 .newPrintSettings;
-
         printSettings.printSilent             = true;
         printSettings.showPrintProgress       = false;
-        printSettings.printBGImages           = true;
-        printSettings.printBGColors           = true;
+        printSettings.printBGImages           = options.printBGImages;
+        printSettings.printBGColors           = options.printBGColors;
         printSettings.printToFile             = true;
         printSettings.toFileName              = file;
         printSettings.printFrameType          = Ci.nsIPrintSettings.kFramesAsIs;
         printSettings.outputFormat            = Ci.nsIPrintSettings.kOutputFormatPDF;
-        printSettings.footerStrCenter         = "";
-        printSettings.footerStrLeft           = "";
-        printSettings.footerStrRight          = "";
-        printSettings.headerStrCenter         = "";
-        printSettings.headerStrLeft           = "";
-        printSettings.headerStrRight          = "";
-        printSettings.marginTop               = options.marginTop;
-        printSettings.marginRight             = options.marginRight;
-        printSettings.marginBottom            = options.marginBottom;
-        printSettings.marginLeft              = options.marginLeft;
-        printSettings.unwriteableMarginTop    = options.unwriteableMarginTop;
-        printSettings.unwriteableMarginRight  = options.unwriteableMarginRight;
-        printSettings.unwriteableMarginBottom = options.unwriteableMarginBottom;
-        printSettings.unwriteableMarginLeft   = options.unwriteableMarginLeft;
+        printSettings.title                   = options.title;
+        printSettings.footerStrCenter         = options.footerStrCenter;
+        printSettings.footerStrLeft           = options.footerStrLeft;
+        printSettings.footerStrRight          = options.footerStrRight;
+        printSettings.headerStrCenter         = options.headerStrCenter;
+        printSettings.headerStrLeft           = options.headerStrLeft;
+        printSettings.headerStrRight          = options.headerStrRight;
+        // Warning! Margins are always in Inches independent of paperSizeUnit
+        printSettings.marginTop               = options.marginTop/25.4;
+        printSettings.marginRight             = options.marginRight/25.4;
+        printSettings.marginBottom            = options.marginBottom/25.4;
+        printSettings.marginLeft              = options.marginLeft/25.4;
+        printSettings.unwriteableMarginTop    = options.unwriteableMarginTop/25.4;
+        printSettings.unwriteableMarginRight  = options.unwriteableMarginRight/25.4;
+        printSettings.unwriteableMarginBottom = options.unwriteableMarginBottom/25.4;
+        printSettings.unwriteableMarginLeft   = options.unwriteableMarginLeft/25.4;
+
         printSettings.resolution              = options.resolution;
         printSettings.paperName               = 'Custom'
         printSettings.paperSizeType           = 1;
         printSettings.paperWidth              = options.width;
         printSettings.paperHeight             = options.height;
         printSettings.paperSizeUnit           = Ci.nsIPrintSettings.kPaperSizeMillimeters;
+        printSettings.shrinkToFit             = options.shrinkToFit;
         printSettings.scaling                 = options.ratio;
+        printSettings.orientation             = options.orientation;
 
         let ms = Cc["@mozilla.org/mime;1"].getService(Ci.nsIMIMEService);
         let mimeInfo = ms.getFromTypeAndExtension("application/pdf", "pdf");


### PR DESCRIPTION
- Fix: render PDF, method was called only with screen options.
- Added to render PDF additional options:
  - page orientation
  - shrinkToFit
  - printBGColors and  printBGImages
  - title
  - print header and footer
- Fix: Margins measurment are in milimeters,  but nsIPrintSettings interface,
  margins are always set in inches, independenly from paperSizeUnit
- Fix: By default paper height and width are get by viewport size in pixels and set pixels as milimeters.
  This was changed to convert pixels in milimeters.