### PR TITLE
Allow navigationRequested hook to block navigation

### DIFF
--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -52,12 +52,12 @@ Navigation.prototype = {
             return result;
 
         // call the navigationRequest callback
-        webpage.navigationRequested(aContentLocation.spec, navtype, !webpage.navigationLocked,
+        var blockNavigation = webpage.navigationRequested(aContentLocation.spec, navtype, !webpage.navigationLocked,
                                     (Ci.nsIContentPolicy.TYPE_DOCUMENT == aContentType));
 
 
         // if the navigation request is blocked, refuse the content
-        if (webpage.navigationLocked) {
+        if (webpage.navigationLocked || blockNavigation) {
             result = Ci.nsIContentPolicy.REJECT_REQUEST;
         }
         return result;


### PR DESCRIPTION
The PR allows the user to prevent extra request, helps to block unneeded JS-initiated fetches.