### PR TITLE
Extend the response given back with _wireBytes which contains the latest progress if any.

### DIFF
--- a/src/modules/slimer-sdk/net-log.js
+++ b/src/modules/slimer-sdk/net-log.js
@@ -16,6 +16,7 @@ Cu.import('resource://slimerjs/slDebug.jsm');
 Cu.import("resource://gre/modules/Services.jsm");
 
 let browserMap = new WeakMap();
+let wireBytes = {};
 
 exports.registerBrowser = function(browser, options) {
     let data = {
@@ -483,7 +484,7 @@ TracingListener.prototype = {
             }
         }
         this.data = [];
-        this.options.onResponse(mix({}, this.response));
+        this.options.onResponse(mix({}, this.response, { _wireBytes: wireBytes[request.URI.spec] }));
     },
 
     QueryInterface: function (aIID) {
@@ -975,6 +976,10 @@ ProgressListener.prototype = {
     onProgressChange : function (aWebProgress, aRequest,
             aCurSelfProgress, aMaxSelfProgress,
             aCurTotalProgress, aMaxTotalProgress) {
+        wireBytes[aRequest.URI.spec] = {
+            current: aCurSelfProgress,
+            total: aCurTotalProgress
+        };
         if (!DEBUG_NETWORK_PROGRESS)
             return;
         if (!(aRequest instanceof Ci.nsIChannel || "URI" in aRequest)) {


### PR DESCRIPTION
This enables you to get the number of bytes transmitted on the wire and if the request is compressed you can then calculate the compression rate using this and bodySize.

This PR is more PoC and may not be done correctly or in the correct place but the feature would be nice.