### PR TITLE
Save a XUL window handle inside the webpage object

### DIFF
--- a/src/modules/slimer-sdk/webpage.js
+++ b/src/modules/slimer-sdk/webpage.js
@@ -35,6 +35,7 @@ netLog.startTracer();
  */
 function create() {
     let [webpage, win] = _create(null);
+    webpage.xulWindow = win;
     return webpage;
 }
 exports.create = create;
@@ -316,6 +317,7 @@ function _create(parentWebpageInfo) {
                 }
             }
             [childPage, win] = _create(parentWPInfo);
+            childPage.xulWindow = win;
 
             if (webpage.ownsPages)
                 privProp.childWindows.push(childPage);


### PR DESCRIPTION
Give the ability to manipulate the webpage's XUL window properties (window title, etc) from the script by saving a reference as `webpage.xulWindow`.