### PR TITLE
Fix for "Permission denied to access property CoffeeScript"

### DIFF
--- a/src/application.ini
+++ b/src/application.ini
@@ -8,4 +8,4 @@ Copyright=Copyright 2012-2015 Laurent Jouanneau & Innophi
 
 [Gecko]
 MinVersion=17.0.0
-MaxVersion=36.*
+MaxVersion=37.*

--- a/src/modules/slLauncher.jsm
+++ b/src/modules/slLauncher.jsm
@@ -97,6 +97,7 @@ var slLauncher = {
                                     'wantXrays': true
                                 });
             let src = slUtils.readChromeFile("resource://slimerjs/coffee-script/extras/coffee-script.js");
+            Cu.evalInSandbox('var CoffeeScript;', coffeeScriptSandbox, 'ECMAv5', 'slLauncher::launchMainScript', 1);
             Cu.evalInSandbox(src, coffeeScriptSandbox, 'ECMAv5', 'coffee-scripts.js', 1);
         }
 


### PR DESCRIPTION
Bump firefox/xulrunner to 37.* and fix "Permission denied to access property CoffeeScript" by defining the CoffeeScript var in the sandbox before running the loaded coffee-script code. #334 