### PR TITLE
Fix `HIDE_ERRORS` switcher

### DIFF
--- a/src/slimerjs
+++ b/src/slimerjs
@@ -142,7 +142,7 @@ for i in $*; do
             CREATE_TEMP=''
             ;;
     esac
-    if [[ $i == --debug* ]] && [[ "$i" == *errors* ]]; then
+    if [[ "$i" == --debug* || "$i" == *errors* ]]; then
         HIDE_ERRORS='N'
     fi
 done


### PR DESCRIPTION
When we use `--debug*`, the `HIDE_ERRORS` is not set to `'N'` because it is in conjunction with `--*errors*`. This must be a disjunction here. So we fix that.

Also, we prevent any potential breaking when comparing the input against `--debug*` by surrounding `$i` with double-quotes.