### PR TITLE
Extract and add HTTP protocol version to the response object

### DIFF
--- a/docs/api/webpage.rst
+++ b/docs/api/webpage.rst
@@ -1566,6 +1566,8 @@ informations:
 - ``statusText``: the HTTP response text for the status ("Ok"...)
 - ``referrer``: the referer url (slimerjs only)
 - ``body``: the content, it may change during multiple call for the same request (slimerjs only).
+- ``httpVersion.major``: the major part of the HTTP protocol version.
+- ``httpVersion.minor``: the minor part of the HTTP protocol version.
 
 
 .. code-block:: javascript

--- a/src/modules/slimer-sdk/net-log.js
+++ b/src/modules/slimer-sdk/net-log.js
@@ -602,8 +602,26 @@ const traceResponse = function(id, request) {
             statusText: null,
             // Extensions
             referrer: "",
-            body: ""
+            body: "",
+            httpVersion: {
+                major: 1,
+                minor: 0
+            }
     };
+
+    // Try to get the HTTP protocol version, may fail due to nsIHttpChannelInternal being internal
+    try {
+        let httpVersionMaj = {};
+        let httpVersionMin = {};
+
+        let channel = request.QueryInterface(Ci.nsIHttpChannelInternal);
+        channel.getResponseVersion(httpVersionMaj, httpVersionMin);
+
+        response.httpVersion.major = httpVersionMaj.value;
+        response.httpVersion.minor = httpVersionMin.value;
+    } catch(e) {
+        // Ignore errors
+    }
 
     try {
         response.status = request.responseStatus;


### PR DESCRIPTION
Done in the same way as Mozilla devtools (toolkit/devtools/webconsole/network-monitor.js NM__httpResponseExaminer())

This is something we will use to see if the response is HTTP/1.x or HTTP/2.

I haven't looked through all documentation, may need to be added somewhere else also.