### PR TITLE
Gecko 40.* support and fix for 'Sandbox must subsume sandboxPrototype'

### DIFF
--- a/src/application.ini
+++ b/src/application.ini
@@ -8,4 +8,4 @@ Copyright=Copyright 2012-2015 Laurent Jouanneau & Innophi
 
 [Gecko]
 MinVersion=17.0.0
-MaxVersion=39.*
+MaxVersion=40.*

--- a/src/modules/slLauncher.jsm
+++ b/src/modules/slLauncher.jsm
@@ -22,6 +22,10 @@ const fileHandler = Cc["@mozilla.org/network/protocol;1?name=file"]
                      .getService(Ci.nsIFileProtocolHandler)
 const systemPrincipal = Cc['@mozilla.org/systemprincipal;1']
                         .createInstance(Ci.nsIPrincipal)
+const appInfo = Cc["@mozilla.org/xre/app-info;1"]
+                .getService(Ci.nsIXULAppInfo);
+const versionComparator = Cc["@mozilla.org/xpcom/version-comparator;1"]
+                          .getService(Ci.nsIVersionComparator);
 
 /**
  * this function retrieves various informations
@@ -92,9 +96,10 @@ var slLauncher = {
             // prepare the sandbox to execute coffee script injected with injectJs
             coffeeScriptSandbox = Cu.Sandbox(contentWindow,
                                 {
-                                    'sandboxName': 'coffeescript',
-                                    'sandboxPrototype': {},
-                                    'wantXrays': true
+                                    sandboxName: 'coffeescript',
+                                    // XULrunner 40.0 and above handles sandboxPrototype different then before
+                                    sandboxPrototype: versionComparator.compare(appInfo.platformVersion, '40') < 0 ? {} : contentWindow,
+                                    wantXrays: true
                                 });
             let src = slUtils.readChromeFile("resource://slimerjs/coffee-script/extras/coffee-script.js");
             Cu.evalInSandbox('var CoffeeScript;', coffeeScriptSandbox, 'ECMAv5', 'slLauncher::launchMainScript', 1);


### PR DESCRIPTION
Hi,

This PR updates the version restriction to 40.* and fixes the 'Sandbox must subsume sandboxPrototype' error by supplying the content window as prototype if the version is 40 or above.

I have tested it with Firefox 40.0 and it seems to work.