### PR TITLE
Bump XULRunner version to 40.0.3

### DIFF
--- a/buildpackage.sh
+++ b/buildpackage.sh
@@ -4,7 +4,7 @@ CURRENTDIR=`pwd`
 SLIMERDIR=`dirname $0`
 SLIMERDIR=`cd $SLIMERDIR;pwd`
 
-XULRUNNER_VERSION="40.0.2"
+XULRUNNER_VERSION="40.0.3"
 XULRUNNER_DNL_URL="http://ftp.mozilla.org/pub/mozilla.org/xulrunner/releases/$XULRUNNER_VERSION/runtimes/"
 XULRUNNER_PACK_NAME="xulrunner-$XULRUNNER_VERSION.en-US"
 


### PR DESCRIPTION
**XULRunner 40.0.3** contains a few fixes, especially for some vulnerabilities discovered in 40.0.2 - [more info](https://www.mozilla.org/en-US/security/known-vulnerabilities/firefox/#firefox40.0.3).

BTW, shouldn't SlimerJS use current ESR version of XULRunner? 38.x.x branch is going to be supported until May 2016 (currently, the newest ESR version is **38.2.1esr**).