### PR TITLE
Fix console.log so it can take multiple arguments

### DIFF
--- a/src/modules/slConsole.jsm
+++ b/src/modules/slConsole.jsm
@@ -87,7 +87,12 @@ function formatTrace(stack) {
     return str;
 }
 
-
+function dumpArguments() {
+    for (var i = 0; i < arguments.length; i++) {
+        dump(arguments[i] + " ");
+    }
+    dump('\n');
+}
 
 function slConsole() {
     this.__exposedProps__ = {
@@ -98,11 +103,11 @@ function slConsole() {
     }
 }
 slConsole.prototype = {
-    log:function(str) { dump(str+"\n");},
-    info:function(str) { dump(str+"\n");},
-    warn:function(str) { dump(str+"\n");},
-    error:function(str) { dump(str+"\n");},
-    debug:function(str) { dump(str+"\n");},
+    log:dumpArguments,
+    info:dumpArguments,
+    warn:dumpArguments,
+    error:dumpArguments,
+    debug:dumpArguments,
     exception: function (e) {
         let [msg, stackRes] = getTraceException(e);
         let str = "An exception occurred" +(e.name ? " "+ e.name: "") +": " +

--- a/test/test-slConsole.js
+++ b/test/test-slConsole.js
@@ -1,0 +1,11 @@
+'use strict';
+
+// This test make sure that console.log can take multiple arguments
+
+// TODO ? Compare the output of console.log()
+// with one argument vs multiple arguments.
+
+console.log('A ' + 'B ' + 'C');
+console.log('A', 'B', 'C');
+
+slimer.exit();


### PR DESCRIPTION
Hello,
I have modified src/modules/slConsole.jsm so that console.log/info/warn/... can take multiple arguments as it should do according to the [API doc.] (https://developer.mozilla.org/en-US/docs/Web/API/Console/log)