### PR TITLE
Remove domWindowUtils.setCSSViewport call for Firefox 44 compatibility

### DIFF
--- a/src/application.ini
+++ b/src/application.ini
@@ -8,7 +8,7 @@ Copyright=Copyright 2012-2015 Laurent Jouanneau & Innophi
 
 [Gecko]
 MinVersion=17.0.0
-MaxVersion=42.*
+MaxVersion=44.*
 
 [XRE]
 EnableExtensionManager=1

--- a/src/modules/slimer-sdk/webpage.js
+++ b/src/modules/slimer-sdk/webpage.js
@@ -862,7 +862,6 @@ function _create(parentWebpageInfo) {
 
             let domWindowUtils = win.QueryInterface(Ci.nsIInterfaceRequestor)
                                     .getInterface(Ci.nsIDOMWindowUtils);
-            domWindowUtils. setCSSViewport(w,h);
             win.resizeTo(w,h);
             domWindowUtils.redraw(1);
         },


### PR DESCRIPTION
This is a quick (but working) fix for:

https://github.com/laurentj/slimerjs/issues/425
https://github.com/laurentj/slimerjs/issues/402

It is working fine with Firefox 44 (the latest on Ubuntu 15.04 in /usr/lib/firefox) now. I have tested this on OS X and Ubuntu 15.04. I am still seeing these "warnings" on the command line:

```
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: Failed to create a SkiaGL DrawTarget, falling back to software
[GFX1-]: Failed to create a SkiaGL DrawTarget, falling back to software
1454812739239 addons.xpi  ERROR startup failed: [Exception... "Component returned failure code: 0x80040111 (NS_ERROR_NOT_AVAILABLE) [nsIXPCComponents_Utils.isModuleLoaded]"
```

But they are not preventing SlimerJS from running correctly. My web font only works in Firefox 44 (another issue for another day), which prompted me to fork this repo and I figured a PR makes sense as well. Thank you for the hard work!