### PR TITLE
Disabled Telemetry.

### DIFF
--- a/src/defaults/preferences/prefs.js
+++ b/src/defaults/preferences/prefs.js
@@ -47,4 +47,8 @@ pref('security.tls.version.min', 1); // no SSLv3 support
 
 pref('extensions.defaultProviders.enabled', false);
 
-
+// Disable Telemetry.
+pref("datareporting.healthreport.service.enabled", false);
+pref("datareporting.healthreport.uploadEnabled", false);
+pref("datareporting.policy.dataSubmissionEnabled", false);
+pref("toolkit.telemetry.unified", false);


### PR DESCRIPTION
This will disable Telemetry which is currently enabled - if you run SlimerJS in GUI mode with -jsconsole before this commit, then after ~2 minutes you may see:
```
Error: 1467794239788	Toolkit.Telemetry	ERROR	TelemetryStorage::loadAbortedSessionPing - error removing ping: PingReadError JS Stack trace: PingReadError@TelemetryStorage.jsm:80:15 < TelemetryStorageImpl.loadPingFile<@TelemetryStorage.jsm:1440:13
Source File: resource://gre/modules/Log.jsm
Line: 749
```