### PR TITLE
Replaced found Expression closures to Arrow functions for Firefox 49 compatibility

### DIFF
--- a/src/modules/addon-sdk/sdk/platform/xpcom.js
+++ b/src/modules/addon-sdk/sdk/platform/xpcom.js
@@ -21,8 +21,8 @@ const { uuid } = require('../util/uuid');
 const Unknown = new function() {
   function hasInterface(component, iid) {
     return component && component.interfaces &&
-      ( component.interfaces.some(function(id) iid.equals(Ci[id])) ||
-        component.implements.some(function($) hasInterface($, iid)) ||
+      ( component.interfaces.some((id) => iid.equals(Ci[id])) ||
+        component.implements.some(($) => hasInterface($, iid)) ||
         hasInterface(Object.getPrototypeOf(component), iid));
   }
 
@@ -85,7 +85,7 @@ const Factory = Class({
    * This method is required by `nsIFactory` interfaces, but as in most
    * implementations it does nothing interesting.
    */
-  lockFactory: function lockFactory(lock) undefined,
+  lockFactory: (lock) => undefined,
   /**
    * If property is `true` XPCOM service / factory will be registered
    * automatically on creation.
@@ -131,7 +131,7 @@ const Factory = Class({
       throw error instanceof Ci.nsIException ? error : Cr.NS_ERROR_FAILURE;
     }
   },
-  create: function create() this.Component()
+  create: () => this.Component()
 });
 exports.Factory = Factory;
 
@@ -148,11 +148,11 @@ const Service = Class({
   /**
    * Creates an instance of the class associated with this factory.
    */
-  create: function create() this.component
+  create: () => this.component
 });
 exports.Service = Service;
 
-function isRegistered({ id }) isCIDRegistered(id)
+var isRegistered = ({ id }) => isCIDRegistered(id);
 exports.isRegistered = isRegistered;
 
 /**
@@ -216,7 +216,7 @@ exports.autoRegister = autoRegister;
 /**
  * Returns registered factory that has a given `id` or `null` if not found.
  */
-function factoryByID(id) classesByID[id] || null
+var factoryByID = (id) => classesByID[id] || null;
 exports.factoryByID = factoryByID;
 
 /**
@@ -225,5 +225,5 @@ exports.factoryByID = factoryByID;
  * with a given `contract` this will return a factory currently associated
  * with a `contract`.
  */
-function factoryByContract(contract) factoryByID(Cm.contractIDToCID(contract))
+var factoryByContract = (contract) => factoryByID(Cm.contractIDToCID(contract));
 exports.factoryByContract = factoryByContract;

--- a/src/modules/addon-sdk/sdk/util/uuid.js
+++ b/src/modules/addon-sdk/sdk/util/uuid.js
@@ -14,4 +14,4 @@ const { generateUUID } = Cc['@mozilla.org/uuid-generator;1'].
 
 // Returns `uuid`. If `id` is passed then it's parsed to `uuid` and returned
 // if not then new one is generated.
-exports.uuid = function uuid(id) id ? parseUUID(id) : generateUUID()
+exports.uuid = (id) => id ? parseUUID(id) : generateUUID();

--- a/src/modules/addon-sdk/toolkit/loader.js
+++ b/src/modules/addon-sdk/toolkit/loader.js
@@ -280,7 +280,7 @@ const load = iced(function load(loader, module, initialSandbox, src) {
       fileName: { value: fileName, writable: true, configurable: true },
       lineNumber: { value: lineNumber, writable: true, configurable: true },
       stack: { value: serializeStack(frames), writable: true, configurable: true },
-      toString: { value: function() toString, writable: true, configurable: true },
+      toString: { value: () => toString, writable: true, configurable: true },
     });
   }
 

--- a/src/modules/slimer-sdk/system.js
+++ b/src/modules/slimer-sdk/system.js
@@ -23,8 +23,8 @@ var OS = {
     architecture: '32bit',
     name: xulRuntime.OS.toLowerCase(),
     version: '',
-    isWindows : function() _isWindows
-}
+    isWindows : () => _isWindows
+};
 
 if (OS.name == 'linux') {
     if (oscpu.indexOf('64') != -1) {

--- a/src/modules/slimer-sdk/webpage.js
+++ b/src/modules/slimer-sdk/webpage.js
@@ -1550,22 +1550,22 @@ function _create(parentWebpageInfo) {
             let requirements = {
                 top: {
                     is: ["undefined", "number"],
-                    ok: function(val)  val === undefined || val >= 0,
+                    ok: (val) => val === undefined || val >= 0,
                     msg: "clipRect.top should be a positive integer"
                 },
                 left: {
                     is: ["undefined", "number"],
-                    ok: function(val)  val === undefined || val >= 0,
+                    ok: (val) => val === undefined || val >= 0,
                     msg: "clipRect.left should be a positive integer"
                 },
                 width: {
                     is: ["undefined", "number"],
-                    ok: function(val) val === undefined || val >= 0,
+                    ok: (val) => val === undefined || val >= 0,
                     msg: "clipRect.width should be a positive integer"
                 },
                 height: {
                     is: ["undefined", "number"],
-                    ok: function(val) val === undefined || val >= 0,
+                    ok: (val) => val === undefined || val >= 0,
                     msg: "clipRect.height should be a positive integer"
                 },
             }


### PR DESCRIPTION
Thanks to this commit the following messages will not be displayed when using newer version of Firefox:

```
JavaScript warning: resource://slimerjs/addon-sdk/toolkit/loader.js, line 283: expression closures are deprecated
JavaScript warning: resource://slimerjs/addon-sdk/toolkit/loader.js -> resource://slimerjs/slimer-sdk/system.js, line 26: expression closures are deprecated
JavaScript warning: resource://slimerjs/addon-sdk/toolkit/loader.js -> resource://slimerjs/slimer-sdk/webpage.js, line 1553: expression closures are deprecated
JavaScript warning: resource://slimerjs/addon-sdk/toolkit/loader.js -> resource://slimerjs/addon-sdk/sdk/platform/xpcom.js, line 24: expression closures are deprecated
JavaScript warning: resource://slimerjs/addon-sdk/toolkit/loader.js -> resource://slimerjs/addon-sdk/sdk/util/uuid.js, line 17: expression closures are deprecated
```

Note that I see these messages using Firefox 49.0a2 but not when using Firefox 46 although [Expression closures](https://developer.mozilla.org/pl/docs/Web/JavaScript/Reference/Operators/Expression_closures) has been deprecated in Firefox 45. Anyway we [should](https://www.fxsitecompat.com/en-CA/docs/2015/expression-closures-are-now-deprecated/) use [Arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) instead.

Note 2: There may be more places where the code should be fixed too.