### PR TITLE
Increase places.sqlite file size by 500KB which is 10MB by default.

### DIFF
--- a/src/defaults/preferences/prefs.js
+++ b/src/defaults/preferences/prefs.js
@@ -52,3 +52,8 @@ pref("datareporting.healthreport.service.enabled", false);
 pref("datareporting.healthreport.uploadEnabled", false);
 pref("datareporting.policy.dataSubmissionEnabled", false);
 pref("toolkit.telemetry.unified", false);
+
+// places.sqlite will grow by 500KB, previously 10MB by default.
+// This will reduce the profile directory size from 12MB to <3MB.
+pref('places.database.growthIncrementKiB', 500);
+


### PR DESCRIPTION
places.sqlite will grow by 500KB,  which is 10MB  by default. This will reduce the profile directory size from 12MB to <3MB during PDF and image conversion.