### PR TITLE
Delete claim that SlimerJS can run headless on Mac

### DIFF
--- a/website/faq.html
+++ b/website/faq.html
@@ -83,7 +83,7 @@
         Gecko, the rendering engine of Firefox, cannot render web content without a
         graphical window.<br />
         You can launch <span class="slm">SlimerJS</span> with xvfb if you are under
-        linux or MacOSx, to have a headless <span class="slm">SlimerJS</span>.<br/>
+        Linux, to have a headless <span class="slm">SlimerJS</span>.<br/>
         <a href="https://github.com/laurentj/slimerjs/issues/80">There is a hope</a>
         for future release of SlimerJS, with latest improvements made in Gecko.
     </dd>


### PR DESCRIPTION
It seems running SlimerJS headless on Mac using Xvfb depends on firefox-x11. The firefox-x11 port has been abandoned.

Refer to https://trac.macports.org/ticket/42087 for more context.