### PR TITLE
Suppressing error if the Webapps module could not be loaded

### DIFF
--- a/src/modules/slConfiguration.jsm
+++ b/src/modules/slConfiguration.jsm
@@ -13,8 +13,16 @@ Cu.import('resource://slimerjs/slErrorLogger.jsm');
 Cu.import('resource://slimerjs/slUtils.jsm');
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import('resource://slimerjs/slDebug.jsm');
-// to avoid issue on navigator object, see https://github.com/laurentj/slimerjs/issues/373
-Cu.import("resource://gre/modules/Webapps.jsm"); 
+
+try {
+    // Importing Webapps module to avoid issue on navigator object.
+    // See: https://github.com/laurentj/slimerjs/issues/373
+
+    Cu.import('resource://gre/modules/Webapps.jsm');
+} catch (e) {
+    // At this moment the "--debug" option has not been parsed yet so the error will be silently suppressed to allow
+    // running SlimerJS under control of Light: https://sourceforge.net/projects/lightfirefox/
+}
 
 var httphandler =  Cc["@mozilla.org/network/protocol;1?name=http"]
                     .getService(Ci.nsIHttpProtocolHandler);


### PR DESCRIPTION
Suppressing error if the Webapps module could not be loaded to allow running SlimerJS under control of Light: https://sourceforge.net/projects/lightfirefox/

Without this fix you will see the following errors if you run SlimerJS under control of [Light](https://sourceforge.net/projects/lightfirefox/):
```
JavaScript error: resource://slimerjs/slConfiguration.jsm, line 16: NS_ERROR_FILE_NOT_FOUND: Component returned failure code: 0x80520012 (NS_ERROR_FILE_NOT_FOUND) [nsIXPCComponents_Utils.import]
JavaScript error: chrome://slimerjs/content/slimerjs.js, line 23: ReferenceError: dumpex is not defined
```

For more info please read https://github.com/laurentj/slimerjs/issues/373