### PR TITLE
Fixed infinite recursion when connecting via proxy which requires an authentication

### DIFF
--- a/docs/api/webpage.rst
+++ b/docs/api/webpage.rst
@@ -1698,6 +1698,8 @@ informations:
 - ``status``: the response status if there is a response
 - ``statusText``: the response status text if there is a response
 
+Note that ``id`` will be null if the error code is ``105``.
+
 List of supported error codes: (see `QNetworkReply codes in QT <http://qt-project.org/doc/qt-5.0/qtnetwork/qnetworkreply.html#NetworkError-enum>`_)
 
 - ``1``: the remote server refused the connection (the server is not accepting requests)
@@ -1713,6 +1715,7 @@ List of supported error codes: (see `QNetworkReply codes in QT <http://qt-projec
 - ``99``: an unknown network-related error was detected
 - ``101``: the connection to the proxy server was refused (the proxy server is not accepting requests)
 - ``103``: the proxy host name was not found (invalid proxy hostname)
+- ``105``: the proxy requires authentication in order to honour the request but did not accept any credentials offered (if any)
 - ``201``: the access to the remote content was denied (similar to HTTP error 401)
 - ``203``: the remote content was not found at the server (similar to HTTP error 404)
 - ``204``: the remote server requires authentication to serve the content but the


### PR DESCRIPTION
Fixed infinite recursion when connecting via proxy which requires an authentication but the authentication credentials were empty or incorrect. Now it will throw an resource error instead of trying to connect using
the same credentials over and over again.

Quick test using `mitmdump` tool from [mitmproxy](http://docs.mitmproxy.org/en/stable/install.html) package:

1. Run `mitmdump --ignore '.*' --singleuser 'correct_user:correct_password' --no-http2 -v`

2. Run SlimerJS using the following parameters:
    - `--proxy='127.0.0.1:8080'`
    - `--proxy='127.0.0.1:8080' --proxy-auth='wrong_user:wrong_password'`
    - `--proxy='127.0.0.1:8080' --proxy-auth='correct_user:correct_password'`

Known issues:
- Request id will be set to `null` when calling `webpage.onResourceError()` callback.
- There is only one allowed authentication attempt. @laurentj: Is there any case when we should allow for more?