### PR TITLE
Fixed bug in fs.copyTree() method

### DIFF
--- a/src/modules/addon-sdk/sdk/io/file.js
+++ b/src/modules/addon-sdk/sdk/io/file.js
@@ -448,6 +448,7 @@ exports.copy = function copy(sourceFileName, targetFileName) {
 
 
 function copyDir(sourceDir, targetDir) {
+    targetDir.create(Ci.nsIFile.DIRECTORY_TYPE, parseInt("0755", 8));
     let enumDir = sourceDir.directoryEntries;
     while(enumDir.hasMoreElements()) {
         let file = enumDir.getNext().QueryInterface(Ci.nsIFile);


### PR DESCRIPTION
Fixed issue with fs.copyTree() method which was not creating the target directory when trying to copy an empty source directory.