### PR TITLE
Add main script to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "bin": {
     "slimerjs": "./src/slimerjs-node"
   },
+  "main": "./src/phantom-protocol.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/laurentj/slimerjs.git"

--- a/src/phantom-protocol.js
+++ b/src/phantom-protocol.js
@@ -1,0 +1,5 @@
+/**
+ * Exposes necessary information so slimerjs will work with phantom drivers.
+ */
+var path = require('path');
+exports.path = path.join(__dirname, '../', 'src', 'slimerjs');


### PR DESCRIPTION
Package.json needs a main script so we are able to require it from JS. This will allow its usage by other phantom drivers. Fixes #563.