### PR TITLE
Completely disable Telemetry

### DIFF
--- a/src/defaults/preferences/prefs.js
+++ b/src/defaults/preferences/prefs.js
@@ -8,6 +8,7 @@ pref("browser.cache.disk.enable", false);
 pref("app.update.enabled", false);
 pref("app.update.auto", false);
 pref("toolkit.telemetry.enabled", false);
+pref("datareporting.healthreport.uploadEnabled", false);
 pref("toolkit.telemetry.prompted", false);
 pref("extensions.blocklist.enabled", false);
 pref("privacy.trackingprotection.enabled", false);


### PR DESCRIPTION
The `datareporting.healthreport.uploadEnabled` pref controls sending the base set of data (OS, architecture, etc.). The `toolkit.telemetry.enabled` controls the additional set of data.