### PR TITLE
Get Windows to call bat file instead of slimerjs command

### DIFF
--- a/src/slimerjs-node
+++ b/src/slimerjs-node
@@ -8,7 +8,9 @@
 var path = require('path');
 var spawn = require('child_process').spawn;
 
-var binPath = path.join(__dirname, 'slimerjs');
+var suffix = process.platform === 'win32' ? '.bat' : '';
+
+var binPath = path.join(__dirname, 'slimerjs' + suffix);
 
 var args = process.argv.slice(2);
 


### PR DESCRIPTION
On Windows, when calling casperjs with `--engine=slimerjs`, I get the following error:

```
Error: spawn C:\...\node_modules\slimerjs\src\slimerjs ENOENT
    at exports._errnoException (util.js:1026:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:193:32)
    at onErrorNT (internal/child_process.js:359:16)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
    at Module.runMain (module.js:606:11)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3
```

This pull request checks if we're on Windows and then calls the `slimerjs.bat` instead of `slimerjs`. This change resolves the above error and CasperJS operates normally.