### PR TITLE
Allow SLIMERDIR to be set using an env var

### DIFF
--- a/src/slimerjs.bat
+++ b/src/slimerjs.bat
@@ -2,7 +2,9 @@
 SETLOCAL EnableDelayedExpansion
 REM % ~ d[rive] p[ath] 0[script name] is the absolute path to this bat file, without quotes, always.
 REM ~ strips quotes from the argument
-SET SLIMERDIR=%~dp0
+IF NOT EXIST "%SLIMERDIR%" (
+    SET SLIMERDIR=%~dp0
+)
 REM %* is every argument passed to this script.
 SET __SLIMER_ARGS=%*
 SET __SLIMER_ENV=


### PR DESCRIPTION
This PR allows SLIMERDIR to be set using an environment variable and only use %~dp0 if not set.

I added this as I'm trying to use slimerjs with backstopjs and somehow %~dp0 is not pointing to the location of slimjerjs.bat, rather my cwd, which causes the application.ini not found error.  With this patch I've been able to use slimerjs successfully.

May help #506.
Original solution found at http://luksurious.me/2014/03/making-casperjs-work-with-slimerjs-on-windows/

Tested on Windows 10 x64.
