### PR TITLE
Update MaxVersion to 55

### DIFF
--- a/src/application.ini
+++ b/src/application.ini
@@ -8,7 +8,7 @@ Copyright=Copyright 2012-2017 Laurent Jouanneau & Innophi
 
 [Gecko]
 MinVersion=38.0.0
-MaxVersion=52.*
+MaxVersion=55.*
 
 [XRE]
 EnableExtensionManager=1


### PR DESCRIPTION
This updates the maximum version to v55 which is the current Nightly branch. SlimerJS works fine with it.

In general — how do you deal with this currently? Do you manually test it completely for each new version? I wonder if maxVersion really is useful at all…?