### PR TITLE
Prioritise require.paths and main script directory over node_modules.

### DIFF
--- a/src/modules/slLauncher.jsm
+++ b/src/modules/slLauncher.jsm
@@ -374,6 +374,25 @@ function prepareLoader(scriptInfo) {
             let requirerUri = Services.io.newURI(requirer.uri, null, null);
             let requirerDir = requirerUri.QueryInterface(Ci.nsIFileURL).file.parent;
 
+            additionalPaths.push(scriptInfo.requirePath);
+
+            // id is not an absolute path or relative path (ex: foo or foo/bar)
+            // let's add all path of requirePaths to search inside them
+            for (let i=0; i < requirePaths.length;i++) {
+                // if path is a relative path, it should be
+                // resolve against the current module path;
+                let path = requirePaths[i];
+                let dir;
+                if (path[0] == '.' || !slUtils.isAbsolutePath(path)) {
+                    const pathToAdd = slUtils.getAbsMozFile(path, requirerDir);
+                    additionalPaths.push(pathToAdd);
+                }
+                else {
+                    const pathToAdd = slUtils.getMozFile(path);
+                    additionalPaths.push(pathToAdd);
+                }
+            }
+
             if (relativeId !== false) {
                 // id is a relative path
                 additionalPaths.push(requirerDir);
@@ -390,22 +409,6 @@ function prepareLoader(scriptInfo) {
                 }
             }
 
-            additionalPaths.push(scriptInfo.requirePath);
-
-            // id is not an absolute path or relative path (ex: foo or foo/bar)
-            // let's add all path of requirePaths to search inside them
-            for (let i=0; i < requirePaths.length;i++) {
-                // if path is a relative path, it should be
-                // resolve against the current module path;
-                let path = requirePaths[i];
-                let dir;
-                if (path[0] == '.' || !slUtils.isAbsolutePath(path)) {
-                    additionalPaths.push(slUtils.getAbsMozFile(path, requirerDir));
-                }
-                else {
-                    additionalPaths.push(slUtils.getMozFile(path));
-                }
-            }
             if (relativeId) {
                 return relativeId;
             }

--- a/test-modules/h.js
+++ b/test-modules/h.js
@@ -1,0 +1,1 @@
+exports.directory = 'test-modules';

--- a/test/g.js
+++ b/test/g.js
@@ -1,0 +1,1 @@
+exports.directory = 'test';

--- a/test/node_modules/g/g.js
+++ b/test/node_modules/g/g.js
@@ -1,0 +1,1 @@
+exports.directory = 'node_modules';

--- a/test/node_modules/h/h.js
+++ b/test/node_modules/h/h.js
@@ -1,0 +1,1 @@
+exports.directory = 'node_modules';

--- a/test/test-require.js
+++ b/test/test-require.js
@@ -120,6 +120,34 @@ describe("require function", function() {
         expect(mod.myname).toEqual('node module');
         expect(mod.submodule).toEqual('sub node module');
     });
+
+    it("should prioritise main script directory over node modules", function() {
+        // Module 'g' exists in both the main test script directory and 'node_modules'.
+        // The resolveURI algorithm should prioritise the main script directory over 'node_modules'
+        var ok = false;
+        try {
+            var g = require('g');
+            ok = true;
+            expect(g.directory).toEqual("test");
+        } catch(e) {
+            ok = false;
+        }
+
+        expect(ok).toBeTruthy();
+
+        var g = require('./g');
+        expect(g.directory).toEqual("test");
+    });
+
+    it("should prioritise require.paths over node modules", function() {
+        // Module 'h' exists in both '../test-modules' and 'node_modules'.
+        // The resolveURI algorithm should prioritise 'require.paths' over 'node_modules'
+        var path = '../test-modules/';
+        require.paths.push (path);
+        var mod = require('h');
+        expect(mod.directory).toEqual('test-modules');
+        require.paths.pop();
+    });
 });
 
 describe("the loaded module requiredexample", function() {


### PR DESCRIPTION
If modules of the same name exist in the `require.paths`/main script directory and in any `node_modules` directory, prioritise `require.paths` and the main script directory over `node_modules`. Fixes #604.