### PR TITLE
Add fake loadinfo to satisfy security checks.

### DIFF
--- a/src/modules/webpageUtils.jsm
+++ b/src/modules/webpageUtils.jsm
@@ -14,6 +14,7 @@ const de = Ci.nsIDocumentEncoder;
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import('resource://slimerjs/httpUtils.jsm');
 Cu.import('resource://slimerjs/slUtils.jsm');
+Cu.import("resource://gre/modules/NetUtil.jsm");
 
 var webpageUtils = {
 
@@ -301,7 +302,13 @@ var webpageUtils = {
         streamChannel.setURI(uri);
         streamChannel.contentStream = stringStream;
 
+        var netChannel = NetUtil.newChannel({
+          uri: uri,
+          loadUsingSystemPrincipal: true,
+        });
+
         var channel = streamChannel.QueryInterface(Ci.nsIChannel);
+        channel.loadInfo = netChannel.loadInfo;
         channel.contentCharset = "UTF-8"
 
         var loadFlags = channel.LOAD_DOCUMENT_URI |


### PR DESCRIPTION
With a debug build of Firefox 58 I get the following fatal assertion "channel needs to have loadInfo to perform security checks". This also helps more tests pass on release builds of Firefox 58.

The fix is rather hacky, but unfortunately seems to be the best way to do it after talking with Christoph:

> it seems there is not an ultimate better solution to what you already came up with. You could rewrite the code to use NetUtil.asyncFetch() [1,2] but I am not sure if it's worth the effort. Besides, they use a very similar approach and transfer the loadInfo from a dummy channel to the newly created channel.
>
>Cheers,
>  Christoph
>
>[1] https://dxr.mozilla.org/mozilla-central/source/browser/extensions/mortar/host/pdf/ppapi-content-sandbox.js#211
>[2] https://dxr.mozilla.org/mozilla-central/source/browser/extensions/pdfjs/content/PdfStreamConverter.jsm#253