### PR TITLE
Replace nsILocalFile with nsIFile

### DIFF
--- a/src/components/filePicker.js
+++ b/src/components/filePicker.js
@@ -32,7 +32,7 @@ filePicker.prototype = {
         list.forEach(function(file){
             try {
                 let selectedFile = Cc['@mozilla.org/file/local;1']
-                                .createInstance(Ci.nsILocalFile);
+                                .createInstance(Ci.nsIFile);
                 selectedFile.initWithPath(file);
                 if (selectedFile.exists()) {
                     finalList.push(selectedFile);

--- a/src/components/httpd.js
+++ b/src/components/httpd.js
@@ -2294,7 +2294,7 @@ function ServerHandler(server)
   this._server = server;
 
   /**
-   * A FileMap object containing the set of path->nsILocalFile mappings for
+   * A FileMap object containing the set of path->nsIFile mappings for
    * all directory mappings set in the server (e.g., "/" for /var/www/html/,
    * "/foo/bar/" for /local/path/, and "/foo/bar/baz/" for /local/path2).
    *
@@ -2744,7 +2744,7 @@ ServerHandler.prototype =
    *
    * @param metadata : Request
    *   the Request for which a response is being generated
-   * @param file : nsILocalFile
+   * @param file : nsIFile
    *   the file which is to be sent in the response
    * @param response : Response
    *   the response to which the file should be written
@@ -3085,7 +3085,7 @@ ServerHandler.prototype =
   },
 
   /**
-   * Returns the nsILocalFile which corresponds to the path, as determined using
+   * Returns the nsIFile which corresponds to the path, as determined using
    * all registered path->directory mappings and any paths which are explicitly
    * overridden.
    *
@@ -3095,7 +3095,7 @@ ServerHandler.prototype =
    *   when the correct action is the corresponding HTTP error (i.e., because no
    *   mapping was found for a directory in path, the referenced file doesn't
    *   exist, etc.)
-   * @returns nsILocalFile
+   * @returns nsIFile
    *   the file to be sent as the response to a request for the path
    */
   _getFileForPath: function(path)
@@ -3460,11 +3460,11 @@ ServerHandler.prototype =
 
 
 /**
- * Maps absolute paths to files on the local file system (as nsILocalFiles).
+ * Maps absolute paths to files on the local file system (as nsIFiles).
  */
 function FileMap()
 {
-  /** Hash which will map paths to nsILocalFiles. */
+  /** Hash which will map paths to nsIFiles. */
   this._map = {};
 }
 FileMap.prototype =
@@ -3472,12 +3472,12 @@ FileMap.prototype =
   // PUBLIC API
 
   /**
-   * Maps key to a clone of the nsILocalFile value if value is non-null;
+   * Maps key to a clone of the nsIFile value if value is non-null;
    * otherwise, removes any extant mapping for key.
    *
    * @param key : string
    *   string to which a clone of value is mapped
-   * @param value : nsILocalFile
+   * @param value : nsIFile
    *   the file to map to key, or null to remove a mapping
    */
   put: function(key, value)
@@ -3489,12 +3489,12 @@ FileMap.prototype =
   },
 
   /**
-   * Returns a clone of the nsILocalFile mapped to key, or null if no such
+   * Returns a clone of the nsIFile mapped to key, or null if no such
    * mapping exists.
    *
    * @param key : string
    *   key to which the returned file maps
-   * @returns nsILocalFile
+   * @returns nsIFile
    *   a clone of the mapped file, or null if no mapping exists
    */
   get: function(key)
@@ -5358,7 +5358,7 @@ function server(port, basePath)
   if (basePath)
   {
     var lp = Cc["@mozilla.org/file/local;1"]
-               .createInstance(Ci.nsILocalFile);
+               .createInstance(Ci.nsIFile);
     lp.initWithPath(basePath);
   }
 

--- a/src/modules/addon-sdk/sdk/platform/xpcom.js
+++ b/src/modules/addon-sdk/sdk/platform/xpcom.js
@@ -199,7 +199,7 @@ function autoRegister(path) {
   var platformVersion = require("../system/xul-app").platformVersion.substring(0, 5);
 
   var file = Cc['@mozilla.org/file/local;1']
-             .createInstance(Ci.nsILocalFile);
+             .createInstance(Ci.nsIFile);
   file.initWithPath(path);
   file.append(osDirName);
   file.append(platformVersion);

--- a/src/modules/addon-sdk/sdk/system.js
+++ b/src/modules/addon-sdk/sdk/system.js
@@ -28,7 +28,7 @@ const PR_TRUNCATE = parseInt("0x20");
 
 function openFile(path, mode) {
   let file = Cc["@mozilla.org/file/local;1"].
-             createInstance(Ci.nsILocalFile);
+             createInstance(Ci.nsIFile);
   file.initWithPath(path);
   let stream = Cc["@mozilla.org/network/file-output-stream;1"].
                createInstance(Ci.nsIFileOutputStream);

--- a/src/modules/addon-sdk/sdk/url.js
+++ b/src/modules/addon-sdk/sdk/url.js
@@ -45,7 +45,7 @@ function resolveResourceURI(uri) {
 
 let fromFilename = exports.fromFilename = function fromFilename(path) {
   var file = Cc['@mozilla.org/file/local;1']
-             .createInstance(Ci.nsILocalFile);
+             .createInstance(Ci.nsIFile);
   file.initWithPath(path);
   return ios.newFileURI(file).spec;
 };

--- a/src/modules/slConsole.jsm
+++ b/src/modules/slConsole.jsm
@@ -107,7 +107,7 @@ function outputStr(str) {
             return;
         }
         var file = Cc['@mozilla.org/file/local;1']
-                  .createInstance(Ci.nsILocalFile);
+                  .createInstance(Ci.nsIFile);
         file.initWithPath('/dev/stdout');
         var filestream = Cc['@mozilla.org/network/file-output-stream;1'].
                      createInstance(Ci.nsIFileOutputStream);

--- a/src/modules/slExit.jsm
+++ b/src/modules/slExit.jsm
@@ -18,7 +18,7 @@ function writeExitStatus (status) {
     }
     let filePath = envService.get('__SLIMER_EXITCODEFILE');
     let file = Cc['@mozilla.org/file/local;1']
-                .createInstance(Ci.nsILocalFile);
+                .createInstance(Ci.nsIFile);
     file.initWithPath(filePath);
 
     let str = String(status);

--- a/src/modules/slUtils.jsm
+++ b/src/modules/slUtils.jsm
@@ -107,7 +107,7 @@ slUtils.getAbsMozFile = function getAbsMozFile(path, basepath) {
     if ( (isWin && first.match(/\:$/)) || (!isWin && first == '')) {
         // this is an absolute path
         file = Cc['@mozilla.org/file/local;1']
-                  .createInstance(Ci.nsILocalFile);
+                  .createInstance(Ci.nsIFile);
         if (isWin) {
             file.initWithPath(path.replace(/\//g, "\\"));
         }
@@ -150,7 +150,7 @@ slUtils.getMozFile = function getMozFile(path) {
     }
 
     let file = Cc['@mozilla.org/file/local;1']
-              .createInstance(Ci.nsILocalFile);
+              .createInstance(Ci.nsIFile);
     file.initWithPath(path);
     return file;
 }

--- a/src/modules/slimer-sdk/webserver.jsm
+++ b/src/modules/slimer-sdk/webserver.jsm
@@ -46,14 +46,14 @@ function create() {
 
         registerFile: function(path, filePath) {
             var file = Components.classes['@mozilla.org/file/local;1']
-                            .createInstance(Components.interfaces.nsILocalFile);
+                            .createInstance(Components.interfaces.nsIFile);
             file.initWithPath(filePath);
             return server.registerFile(path, file);
         },
 
         registerDirectory : function(path, directoryPath) {
             var file = Components.classes['@mozilla.org/file/local;1']
-                            .createInstance(Components.interfaces.nsILocalFile);
+                            .createInstance(Components.interfaces.nsIFile);
             file.initWithPath(directoryPath);
             return server.registerDirectory(path, file);
         },


### PR DESCRIPTION
As of Firefox 57, nsILocalFile has been removed. However, nsIFile can be used in its place. See [Bug 1375125](https://bugzilla.mozilla.org/show_bug.cgi?id=1375125) for details.