### PR TITLE
Fix generator syntax

### DIFF
--- a/src/modules/addon-sdk/sdk/deprecated/api-utils.js
+++ b/src/modules/addon-sdk/sdk/deprecated/api-utils.js
@@ -121,7 +121,7 @@ exports.validateOptions = function validateOptions(options, requirements) {
 };
 
 exports.addIterator = function addIterator(obj, keysValsGenerator) {
-  obj.__iterator__ = function(keysOnly, keysVals) {
+  obj.__iterator__ = function*(keysOnly, keysVals) {
     let keysValsIterator = keysValsGenerator.call(this);
 
     // "for (.. in ..)" gets only keys, "for each (.. in ..)" gets values,


### PR DESCRIPTION
In `addon-sdk/sdk/deprecated/api-utils.js` there is a `yield` statement but it's not inside a generator. Recent versions of Firefox (either 56 or 57 I think) correctly report `yield` as a reserved word and fail on this code. Presumably this function was supposed to be a generator function.