### PR TITLE
In case we can not open an output return the fallback implementation

### DIFF
--- a/src/modules/slimer-sdk/system.js
+++ b/src/modules/slimer-sdk/system.js
@@ -193,13 +193,14 @@ var stdin = null;
 var currentEncoding = '';
 
 function getOutput(file, stream) {
-    if (_isWindows) {
-        return {
-            write: dump,
-            writeLine: function (data) {
-                dump(data + '\n');
-            }
+    var fallback = {
+        write: dump,
+        writeLine: function (data) {
+            dump(data + '\n');
         }
+    }
+    if (_isWindows) {
+        return fallback;
     }
     if (stream) {
         if (currentEncoding == slConfiguration.outputEncoding) {
@@ -208,14 +209,18 @@ function getOutput(file, stream) {
         stream.close();
     }
     currentEncoding = slConfiguration.outputEncoding;
-    if (currentEncoding == 'binary') {
-        stream = fs.open(file, { mode:'bw'});
-    }
-    else {
-        stream = fs.open(file,
-                         { mode:'w',
-                           charset:currentEncoding,
-                           nobuffer:true});
+    try {
+        if (currentEncoding == 'binary') {
+            stream = fs.open(file, { mode:'bw'});
+        }
+        else {
+            stream = fs.open(file,
+                             { mode:'w',
+                               charset:currentEncoding,
+                               nobuffer:true});
+        }
+    } catch (e) {
+        return fallback;
     }
     return stream;
 }


### PR DESCRIPTION
This is fix for issue #478 

The problem is caused by nodejs, when child process is created using child_process.spawn. In this case stdin/stdout is piped to a socket, but it's not accessible by the child process. I could reproduce it with a simple .js and sh file:

  /dev/stdout: symbolic link to /proc/self/fd/1
  /proc/self/fd/1: broken symbolic link to socket:[5891187]

I'm not sure it's a bug or a feature in nodejs, but it behaves like this since v4.0. So I suggest the best to do is not to reference /dev/stdin / /dev/stdout directly

This fix falls back to the "dump" implementation when the requested output is not available

