### PR TITLE
Fix file picker logic for FF < v54

### DIFF
--- a/src/components/filePicker.js
+++ b/src/components/filePicker.js
@@ -312,7 +312,7 @@ filePicker.prototype = {
                 for (let i = 0; i < this._nsfiles.length; ++i) {
                     if (this._nsfiles[i].exists()) {
                         if (geckoMajorVersion < 54) {
-                            this.domWindowUtils.wrapDOMFile(this._nsfiles[i]);
+                            this._nsDOMFiles.push(this.domWindowUtils.wrapDOMFile(this._nsfiles[i]));
                         }
                         else {
                             let promise =


### PR DESCRIPTION
This logic was updated recently for FF54+, but this line was incomplete and ended up breaking the file picker in FF53 and below. This corrects that issue so that the file picker works in all versions.