### PR TITLE
Redirect exception to page.onError when executing other event-listeners

### DIFF
--- a/src/modules/slimer-sdk/webpage.js
+++ b/src/modules/slimer-sdk/webpage.js
@@ -1910,7 +1910,11 @@ function _create(parentWebpageInfo) {
             try {
                 return page[listener].apply(page, args);
             } catch(e) {
-                console.log("Error "+listener+": ["+e.name+"] "+e.message+" ("+e.fileName+" ; line:"+e.lineNumber+" col:"+e.columnNumber+")");
+                if (listener !== "onError" && page["onError"]) {
+                    executePageListener(page, "onError", getTraceException(e, ''));
+                } else {
+                    console.log("Error "+listener+": ["+e.name+"] "+e.message+" ("+e.fileName+" ; line:"+e.lineNumber+" col:"+e.columnNumber+")");
+                }
             }
         }
     }


### PR DESCRIPTION
This patch modifies executeEventListener function to call page.onError
listener when there is an exception while executing any listener
callback function.  The modification checks to not call onError listener
recursively.

This patch allows user scripts to listen for any errors in onError
function callback. By default, the exception handler in
executeEventListener absorbs all errors and do not propagate them, which
may hang the execution script if its waiting for any callbacks to
finish.

Signed-off-by: Avadh Patel <avadh4all@gmail.com>