### PR TITLE
Firefox v59 Compatibility

### DIFF
--- a/src/application.ini
+++ b/src/application.ini
@@ -8,7 +8,7 @@ Copyright=Copyright 2012-2017 Laurent Jouanneau & Innophi
 
 [Gecko]
 MinVersion=53.0.0
-MaxVersion=58.*
+MaxVersion=59.*
 
 [XRE]
 EnableExtensionManager=1

--- a/src/modules/addon-sdk/sdk/clipboard.js
+++ b/src/modules/addon-sdk/sdk/clipboard.js
@@ -79,8 +79,11 @@ exports.set = function(aData, aDataType) {
       options.datatype = dataURL.mimeType;
       options.data = dataURL.data;
     }
-    catch (e if e.name === "URIError") {
+    catch (e) {
       // Not a valid Data URL
+      if (e.name !== "URIError") {
+        throw e;
+      }
     }
   }
 

--- a/src/modules/addon-sdk/sdk/url.js
+++ b/src/modules/addon-sdk/sdk/url.js
@@ -27,12 +27,15 @@ function newURI(uriStr, base) {
     let baseURI = base ? ios.newURI(base, null, null) : null;
     return ios.newURI(uriStr, null, baseURI);
   }
-  catch (e if e.result == Cr.NS_ERROR_MALFORMED_URI) {
-    throw new Error("malformed URI: " + uriStr);
-  }
-  catch (e if (e.result == Cr.NS_ERROR_FAILURE ||
-               e.result == Cr.NS_ERROR_ILLEGAL_VALUE)) {
-    throw new Error("invalid URI: " + uriStr);
+  catch (e) {
+    if (e.result == Cr.NS_ERROR_MALFORMED_URI) {
+      throw new Error("malformed URI: " + uriStr);
+    } else if (e.result == Cr.NS_ERROR_FAILURE ||
+               e.result == Cr.NS_ERROR_ILLEGAL_VALUE) {
+      throw new Error("invalid URI: " + uriStr);
+    } else {
+      throw e;
+    }
   }
 }
 
@@ -40,8 +43,12 @@ function resolveResourceURI(uri) {
   var resolved;
   try {
     resolved = resProt.resolveURI(uri);
-  } catch (e if e.result == Cr.NS_ERROR_NOT_AVAILABLE) {
-    throw new Error("resource does not exist: " + uri.spec);
+  } catch (e) {
+    if (e.result == Cr.NS_ERROR_NOT_AVAILABLE) {
+      throw new Error("resource does not exist: " + uri.spec);
+    } else {
+      throw e;
+    }
   };
   return resolved;
 }
@@ -62,8 +69,12 @@ let toFilename = exports.toFilename = function toFilename(url) {
     try {
       channel = channel.QueryInterface(Ci.nsIFileChannel);
       return channel.file.path;
-    } catch (e if e.result == Cr.NS_NOINTERFACE) {
-      throw new Error("chrome url isn't on filesystem: " + url);
+    } catch (e) {
+      if (e.result == Cr.NS_NOINTERFACE) {
+        throw new Error("chrome url isn't on filesystem: " + url);
+      } else {
+        throw e;
+      }
     }
   }
   if (uri.scheme == "file") {
@@ -83,17 +94,29 @@ function URL(url, base) {
   var userPass = null;
   try {
     userPass = uri.userPass ? uri.userPass : null;
-  } catch (e if e.result == Cr.NS_ERROR_FAILURE) {}
+  } catch (e) {
+    if (e.result != Cr.NS_ERROR_FAILURE) {
+      throw e;
+    }
+  }
 
   var host = null;
   try {
     host = uri.host;
-  } catch (e if e.result == Cr.NS_ERROR_FAILURE) {}
+  } catch (e) {
+    if (e.result != Cr.NS_ERROR_FAILURE) {
+      throw e;
+    }
+  }
 
   var port = null;
   try {
     port = uri.port == -1 ? null : uri.port;
-  } catch (e if e.result == Cr.NS_ERROR_FAILURE) {}
+  } catch (e) {
+    if (e.result != Cr.NS_ERROR_FAILURE) {
+      throw e;
+    }
+  }
 
   let uriPath = (geckoMajorVersion >= 57 ? uri.pathQueryRef: uri.path);
 

--- a/src/modules/slimer-sdk/phantom.jsm
+++ b/src/modules/slimer-sdk/phantom.jsm
@@ -230,12 +230,15 @@ var phantom = {
             let baseURI = base ? Services.io.newURI(base, null, null) : null;
             return Services.io.newURI(url, null, baseURI).spec;
         }
-        catch (e if e.result == Cr.NS_ERROR_MALFORMED_URI) {
-            throw new Error("malformed URI: " + url);
-        }
-        catch (e if (e.result == Cr.NS_ERROR_FAILURE ||
-                     e.result == Cr.NS_ERROR_ILLEGAL_VALUE)) {
-            throw new Error("invalid URI: " + url);
+        catch (e) {
+            if (e.result == Cr.NS_ERROR_MALFORMED_URI) {
+                throw new Error("malformed URI: " + url);
+            } else if (e.result == Cr.NS_ERROR_FAILURE ||
+                       e.result == Cr.NS_ERROR_ILLEGAL_VALUE) {
+                throw new Error("invalid URI: " + url);
+            } else {
+                throw e;
+            }
         }
     },
 


### PR DESCRIPTION
Firefox v59 removes support for non-standard conditional catch clauses: https://developer.mozilla.org/en-US/Firefox/Releases/59#JavaScript_2. These have been replaced with the equivilent catch and conditional logic blocks.

I've also updated the `MaxVersion` from 58.* to 59.*

The tests pass the same way they have for previous version with 4 out of 399 tests failing (which have been failing for some time).

I'm submitting a separate PR to fix the Dockerfile for testing in TravisCI.