### PR TITLE
Remove info about headless from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ with an external Javascript script: opening a webpage, clicking on links, modify
 It is useful to do functional tests, page automation, network monitoring, screen capture etc.
 
 It is a tool like [PhantomJs](http://phantomjs.org/), except that
-it runs Gecko instead of Webkit, and it is not (yet) natively headless.
-However, it can be headless with the use of xvfb under Linux (but not on MacOS).
+it runs Gecko instead of Webkit.
 
 SlimerJS provides the same API of PhantomJS. The current version of SlimerJS
 is highly compatible with PhantomJS 1.9.


### PR DESCRIPTION
Headless Firefox works on Fx55+ on Linux, and 56+ on Windows/Mac. (Using `MOZ_HEADLESS=1`)
https://developer.mozilla.org/en-US/Firefox/Headless_mode

Tested on mac and docker

Should we add some info in docs about how to run it in headless mode?