### PR TITLE
Add async-await example

### DIFF
--- a/examples/async_await.js
+++ b/examples/async_await.js
@@ -1,0 +1,61 @@
+const webserver = require("webserver");
+const webpage = require("webpage");
+const system = require('system');
+
+const sleep = (ms) => {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+(async () => {
+  page = webpage.create();
+  var isLoading = false;
+
+  page.onLoadStarted = (url, isFrame) => {
+    console.log(`Loading: ${url}`);
+    isLoading = true;
+  };
+
+  page.onLoadFinished = (status, url, isFrame) => {
+    console.log(`Loaded ${url}  (${status})`);
+    isLoading = false;
+  };
+
+  page.onConsoleMessage = (message, line, file) => {
+    console.log(`LOG: ${message} -- ${file}:${line}`);
+  };
+
+  await page.open('https://news.ycombinator.com');
+
+  await page.evaluate(() => {
+    var field = document.querySelector('input[name=q]');
+    field.value = "Slimerjs";
+
+    console.log('Searching "Slimerjs" on HackerNews');
+
+    field.parentNode.submit();
+  });
+
+  console.log(`Waiting saerch results page to load`);
+
+  while (!page.url.match(/Slimerjs/i) || isLoading || !page.plainText.match(/Slimerjs/i)) {
+    await sleep(300);
+    system.stdout.write('.');
+  }
+  system.stdout.write('\n');
+
+  console.log(`Page content:\n${page.plainText}`);
+
+  slimer.exit();
+})().catch(error => {
+  if (error.message && error.stack) {
+    console.log(`Script Error: ${error.constructor.prototype.name}: ${error.message}`);
+    error.stack.split("\n").forEach(line => {
+      if (line.trim() != "") {
+        console.log(`         -> ${line}`);
+      }
+    });
+  } else {
+    console.log(`Script Error: ${error}`);
+  }
+  slimer.exit(1);
+});


### PR DESCRIPTION
Just example of how to use async/await and form submission

Do you think this a good example how to benefit from using async/await?

* Error handling is little big because `phantom.defaultErrorHandler` didn't show stacktrace (it expect stack to be array of objects, but plain js has `error.stack` as a string)
* And `system.stderr.write` doesn't print anything, is it expected?

Output will be:

```
Loading: https://news.ycombinator.com/ 
Loaded https://news.ycombinator.com/  (success) 
LOG: Searching "Slimerjs" on HackerNews -- phantomjs://webpage.evaluate():5 
Loading: https://hn.algolia.com/?q=Slimerjs 
Waiting saerch results page to load 
...........Loaded https://hn.algolia.com/?q=Slimerjs  (success) 
.
Page content:

SlimerJS – A scriptable browser for Web developers

    93 points T-A 3 years ago 27 comments 

SlimerJS: a replacement for PhantomJS using recent Firefox

    81 points fanf2 18 days ago 34 comments 

Headless SlimerJS with Firefox

    4 points zspitzer a year ago 0 comments 

SlimerJS meets Ruby = Yabbie

    2 points bernardeli 3 years ago 0 comments 

A Ruby gem to wrap SlimerJS

    2 points lucascaton 4 years ago 0 comments 

Tada Here is SlimerJS

    2 points blueveek 5 years ago 0 comments 

SlimerJS, a scriptable browser for Web developers

    2 points tbassetto 5 years ago 0 comments 

SlimerJS

    1 points DanielRibeiro 5 years ago 0 comments 

SlimerJS: A scriptable browser for Web developers

    1 points viana007 5 years ago 0 comments 

SlimerJS is a scriptable browser like PhantomJS, except it runs under Gecko

    1 points bpierre 5 years ago 0 comments 

SlimerJS, a PhantomJS-like tool running Gecko

    1 points bpierre 5 years ago 0 comments 

SlimerJS : A PhantomJS-like tool running Gecko

    1 points mauricesvay 5 years ago 0 comments 

PhantomJS Alternative? How to “Compute” JavaScript Manipulated HTML?

    3 points taewookim 2 years ago 1 comment 

Is there a headless browser (or equivalent) that can render out HTML after 3rd party JS's have added their images/text? (ex. ad sense)

I've tried PhantomJS, CasperJS, and SlimerJS but none can seem to evaluate HTML after JS from an iframe has been called.
An headless Firefox is (apparently) coming

    2 points enrico50 a year ago 0 comments 

Secret Lair of the Jedi, the Grail and Green Slimers (1989)

    1 points wilfra 5 years ago 0 comments 

    About • Settings • Help • API • Hacker News • Fork/Contribute • Status • Cool apps
```
