### PR TITLE
Fix for cookie expires attribute

### DIFF
--- a/src/modules/slCookiesManager.jsm
+++ b/src/modules/slCookiesManager.jsm
@@ -40,7 +40,7 @@ function initCookieFromnsICookie(nsCookie) {
         c.expiry = null;
     }
     else {
-        c.expires = (new Date(nsCookie.expires)).toString();
+        c.expires = (new Date(nsCookie.expires * 1000)).toString();
         c.expiry = nsCookie.expiry;
     }
     return c;


### PR DESCRIPTION
Cookies obtained from page.cookies should now have an accurate 'expires' attribute.

The Date() constructor accepts milliseconds from epoch as its parameter, but nsCookie.expires is in seconds, leading to some wacky dates.

Would fix #718.