### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -52,7 +52,7 @@ depends on many different things:
 So, don't expect to have exactly the same results between any browser and SlimerJS.
 Moreover, as SlimerJS is executed on top of Firefox, so **At least, the rendering
 with SlimerJs may be exactly the same as with Firefox** (same gecko version, on the
-same operating system). However you could have some difference in some extrem
+same operating system). However you could have some difference in some extremum
 case (high zooming for example) and with different operating system (even it is
 the same gecko version).
 

--- a/docs/manual/addons.rst
+++ b/docs/manual/addons.rst
@@ -73,7 +73,7 @@ Steps to install extensions:
 - 4. Set User Prefs extensions.xpiState (prefs.js)
    Add-ons need to be loaded. As a UI is missing to load an extension, you need
    to set user preferences manually. This is done in the profile dir prefs.js
-   file. The value is a JSON object (be careful with masking quots and
+   file. The value is a JSON object (be careful with masking quotes and
    structure). You need to set EXTENSION_ID, realFolderToExtension and VERSION
    accordingly. The timestamps fields (st and mt) should be filled with recent
    timestamps. Everything in the near past should do.

--- a/src/modules/addon-sdk/toolkit/loader.js
+++ b/src/modules/addon-sdk/toolkit/loader.js
@@ -7,7 +7,7 @@
 /**
  * this files does originally come from the Mozilla project (addons-sdk)
  * resource://gre/modules/commonjs/loader.js
- * Some functionnalities have been added:
+ * Some functionalities have been added:
  *  - the possibility to indicate the javascript version in the loader options
  *    to evaluate modules with this version.
  *  - the possiblity to indicate our own sandbox for the module loading

--- a/src/modules/slimer-sdk/net-log.js
+++ b/src/modules/slimer-sdk/net-log.js
@@ -348,7 +348,7 @@ TracingListener.prototype = {
         }
 
         if (this.originalRequest.status == Cr.NS_BINDING_REDIRECTED) {
-            // when there is a redirection, the original chanel has this status
+            // when there is a redirection, the original channel has this status
             // but we receive as "request" argument the new channel. We should ignore
             // this new channel because it has its own TracingListener
             this.response = traceResponse(this.index, this.originalRequest);

--- a/test/jasmine/jasmine.js
+++ b/test/jasmine/jasmine.js
@@ -305,7 +305,7 @@ jasmine.Spy = function(name) {
 };
 
 /**
- * Tells a spy to call through to the actual implemenatation.
+ * Tells a spy to call through to the actual implementation.
  *
  * @example
  * var foo = {
@@ -528,7 +528,7 @@ var expect = function(actual) {
 if (isCommonJS) exports.expect = expect;
 
 /**
- * Defines part of a jasmine spec.  Used in cominbination with waits or waitsFor in asynchrnous specs.
+ * Defines part of a jasmine spec.  Used in combination with waits or waitsFor in asynchrnous specs.
  *
  * @param {Function} func Function that defines part of a jasmine spec.
  */


### PR DESCRIPTION
There are small typos in:
- docs/faq.rst
- docs/manual/addons.rst
- src/modules/addon-sdk/toolkit/loader.js
- src/modules/slimer-sdk/net-log.js
- test/jasmine/jasmine.js

Fixes:
- Should read `quotes` rather than `quots`.
- Should read `implementation` rather than `implemenatation`.
- Should read `functionalities` rather than `functionnalities`.
- Should read `extremum` rather than `extrem`.
- Should read `combination` rather than `cominbination`.
- Should read `channel` rather than `chanel`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md