### PR TITLE
bringing back --version

### DIFF
--- a/src/slimerjs
+++ b/src/slimerjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+VER="1.0.0" # Version of SlimerJS for --version
+
 #retrieve full path of the current script
 # symlinks are resolved, so application.ini could be found
 # this code comes from http://stackoverflow.com/questions/59895/
@@ -117,6 +119,10 @@ for i in $*; do
     case "$i" in
         --help|-h)
            showHelp
+           exit 0
+           ;;
+        --version|-v)
+           echo $VER
            exit 0
            ;;
         -reset-profile|-profile|-p|-createprofile|-profilemanager)


### PR DESCRIPTION
some libraries need the --version parameter. it's in the help and it's not respected.

Adding a variable at the top to be able to change it as needed for easy maintenance